### PR TITLE
Replace all include guards with names that aren't reserved.

### DIFF
--- a/include/tls/cache.h
+++ b/include/tls/cache.h
@@ -1,5 +1,5 @@
-#ifndef __TLS_CACHE
-#define __TLS_CACHE
+#ifndef TLS_CACHE
+#define TLS_CACHE
 
 #include <algorithm>
 
@@ -56,4 +56,4 @@ namespace tls {
 
 }
 
-#endif // !__TLS_CACHE
+#endif // !TLS_CACHE

--- a/include/tls/replicator.h
+++ b/include/tls/replicator.h
@@ -1,5 +1,5 @@
-﻿#ifndef __TLS_REPLICATOR_H
-#define __TLS_REPLICATOR_H
+﻿#ifndef TLS_REPLICATOR_H
+#define TLS_REPLICATOR_H
 
 #include <shared_mutex>
 #include <vector>
@@ -180,4 +180,4 @@ namespace tls {
         std::shared_mutex mtx;
     };
 }
-#endif // !__TLS_REPLICATOR_H
+#endif // !TLS_REPLICATOR_H

--- a/include/tls/splitter.h
+++ b/include/tls/splitter.h
@@ -1,5 +1,5 @@
-#ifndef __TLS_SPLITTER_H
-#define __TLS_SPLITTER_H
+#ifndef TLS_SPLITTER_H
+#define TLS_SPLITTER_H
 
 #include <mutex>
 #include <vector>
@@ -151,4 +151,4 @@ protected:
     };
 }
 
-#endif // !__TLS_SPLITTER_H
+#endif // !TLS_SPLITTER_H


### PR DESCRIPTION
The ECS library uses this library, which has a similar issue of using double underscore names which are reserved by the compiler. since these include guards were already all prefixed with TLS_ I've just removed the __ to make these names compliant.