### PR TITLE
Made tls::collect useable in constexpr functions

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -31,8 +31,7 @@
       "cmakeCommandArgs": "",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": []
+      "inheritEnvironments": [ "msvc_x64_x64" ]
     }
   ]
 }

--- a/examples/collect/concurrent_fill_vector/concurrent_fill_vector.cpp
+++ b/examples/collect/concurrent_fill_vector/concurrent_fill_vector.cpp
@@ -47,7 +47,7 @@ int main() {
 
     // Run some concurrent code that would normally create a data race
     tls::collect<std::vector<int>> vec;
-    auto const worker = [&vec, chunk_size](int start) {
+    auto const worker = [&](int start) {
         auto& local = vec.local();
         for (int i = start; i < start + chunk_size; i++)
             local.push_back(i);

--- a/include/tls/collect.h
+++ b/include/tls/collect.h
@@ -76,6 +76,7 @@ private:
 	// All the data collected from threads
 	std::vector<T> data{};
 
+	// Data that is only used in constexpr evaluations
 	thread_data consteval_data;
 
 	// Mutex for serializing access for adding/removing thread-local instances

--- a/include/tls/collect.h
+++ b/include/tls/collect.h
@@ -2,6 +2,7 @@
 #define TLS_COLLECT_H
 
 #include <mutex>
+#include <variant>
 #include <vector>
 
 namespace tls {
@@ -17,14 +18,14 @@ class collect {
 	// Its lifetime is marked as thread_local, which means that it can live longer than
 	// the splitter<> instance that spawned it.
 	struct thread_data {
-		~thread_data() noexcept {
+		constexpr ~thread_data() noexcept {
 			if (owner != nullptr) {
 				owner->remove_thread(this);
 			}
 		}
 
 		// Return a reference to an instances local data
-		T &get(collect *instance) noexcept {
+		[[nodiscard]] constexpr T& get(collect* instance) noexcept {
 			// If the owner is null, (re-)initialize the thread.
 			// Data may still be present if the thread_local instance is still active
 			if (owner == nullptr) {
@@ -35,7 +36,7 @@ class collect {
 			return data;
 		}
 
-		void remove(collect *instance) noexcept {
+		constexpr void remove(collect* instance) noexcept {
 			if (owner == instance) {
 				data = {};
 				owner = nullptr;
@@ -43,143 +44,196 @@ class collect {
 			}
 		}
 
-		T *get_data() noexcept {
+		[[nodiscard]] constexpr T* get_data() noexcept {
 			return &data;
 		}
-		T const *get_data() const noexcept {
+		[[nodiscard]] constexpr T const* get_data() const noexcept {
 			return &data;
 		}
 
-		void set_next(thread_data *ia) noexcept {
+		constexpr void set_next(thread_data* ia) noexcept {
 			next = ia;
 		}
-		thread_data *get_next() noexcept {
+		[[nodiscard]] constexpr thread_data* get_next() noexcept {
 			return next;
 		}
-		thread_data const *get_next() const noexcept {
+		[[nodiscard]] constexpr thread_data const* get_next() const noexcept {
 			return next;
 		}
 
 	private:
 		T data{};
-		collect *owner{};
-		thread_data *next = nullptr;
+		collect* owner{};
+		thread_data* next = nullptr;
 	};
 
 private:
 	// the head of the threads that access this splitter instance
-	thread_data *head{};
+	thread_data* head{};
 
 	// All the data collected from threads
-	std::vector<T> data;
+	std::vector<T> data{};
+
+	thread_data consteval_data;
 
 	// Mutex for serializing access for adding/removing thread-local instances
-	std::mutex mtx_storage;
+	[[nodiscard]] std::mutex& get_runtime_mutex() noexcept {
+		static std::mutex s_mtx{};
+		return s_mtx;
+	}
 
-protected:
 	// Adds a new thread
-	void init_thread(thread_data *t) noexcept {
-		std::scoped_lock sl(mtx_storage);
+	constexpr void init_thread(thread_data* t) noexcept {
+		auto const init_thread_imp = [&]() noexcept {
+			t->set_next(head);
+			head = t;
+		};
 
-		t->set_next(head);
-		head = t;
+		if (!std::is_constant_evaluated()) {
+			std::scoped_lock sl(get_runtime_mutex());
+			init_thread_imp();
+		} else {
+			init_thread_imp();
+		}
 	}
 
 	// Removes the thread
-	void remove_thread(thread_data *t) noexcept {
-		std::scoped_lock sl(mtx_storage);
+	constexpr void remove_thread(thread_data* t) noexcept {
+		auto const remove_thread_impl = [&]() noexcept {
+			// Take the thread data
+			T* local_data = t->get_data();
+			data.push_back(std::move(*local_data));
 
-		// Take the thread data
-		T *local_data = t->get_data();
-		data.push_back(std::move(*local_data));
+			// Reset the thread data
+			*local_data = T{};
 
-		// Reset the thread data
-		*local_data = T{};
-
-		// Remove the thread from the linked list
-		if (head == t) {
-			head = t->get_next();
-		} else {
-			auto curr = head;
-			while (curr->get_next() != nullptr) {
-				if (curr->get_next() == t) {
-					curr->set_next(t->get_next());
-					return;
-				} else {
-					curr = curr->get_next();
+			// Remove the thread from the linked list
+			if (head == t) {
+				head = t->get_next();
+			} else {
+				auto curr = head;
+				while (curr->get_next() != nullptr) {
+					if (curr->get_next() == t) {
+						curr->set_next(t->get_next());
+						return;
+					} else {
+						curr = curr->get_next();
+					}
 				}
 			}
+		};
+
+		if (!std::is_constant_evaluated()) {
+			std::scoped_lock sl(get_runtime_mutex());
+			remove_thread_impl();
+		} else {
+			remove_thread_impl();
 		}
 	}
 
 public:
-	collect() noexcept = default;
-	collect(collect const &) = delete;
-	collect(collect &&) noexcept = default;
-	collect &operator=(collect const &) = delete;
-	collect &operator=(collect &&) noexcept = default;
-	~collect() noexcept {
+	constexpr collect() noexcept {}
+	constexpr collect(collect const&) = delete;
+	constexpr collect(collect&&) noexcept = default;
+	constexpr collect& operator=(collect const&) = delete;
+	constexpr collect& operator=(collect&&) noexcept = default;
+	constexpr ~collect() noexcept {
 		reset();
 	}
 
 	// Get the thread-local thread of T
-	T &local() noexcept {
-		thread_local thread_data var{};
-		return var.get(this);
+	[[nodiscard]] constexpr T& local() noexcept {
+		if (!std::is_constant_evaluated()) {
+			auto const local_impl = [&]() -> T& {
+				thread_local thread_data var{};
+				return var.get(this);
+			};
+			return local_impl();
+		} else {
+			return consteval_data.get(this);
+		}
 	}
 
 	// Gathers all the threads data and returns it. This clears all stored data.
-	std::vector<T> gather() noexcept {
-		std::scoped_lock sl(mtx_storage);
+	[[nodiscard]] constexpr std::vector<T> gather() noexcept {
+		auto const gather_impl = [&]() noexcept {
+			for (thread_data* thread = head; thread != nullptr; thread = thread->get_next()) {
+				data.push_back(std::move(*thread->get_data()));
+				*thread->get_data() = T{};
+			}
 
-		for (thread_data *thread = head; thread != nullptr; thread = thread->get_next()) {
-			data.push_back(std::move(*thread->get_data()));
-			*thread->get_data() = T{};
+			return std::move(data);
+		};
+
+		if (!std::is_constant_evaluated()) {
+			std::scoped_lock sl(get_runtime_mutex());
+			return gather_impl();
+		} else {
+			return gather_impl();
 		}
-
-		return std::move(data);
 	}
 
 	// Gathers all the threads data and sends it to the output iterator. This clears all stored data.
-	void gather_flattened(std::output_iterator<typename T::value_type> auto dest) noexcept {
-		std::scoped_lock sl(mtx_storage);
+	[[nodiscard]] constexpr void gather_flattened(std::output_iterator<typename T::value_type> auto dest) noexcept {
+		auto const gather_flattened_impl = [&]() noexcept {
+			for (T& t : data) {
+				std::move(t.begin(), t.end(), dest);
+			}
+			data.clear();
 
-		for (T& t : data) {
-			std::move(t.begin(), t.end(), dest);
-		}
-		data.clear();
+			for (thread_data* thread = head; thread != nullptr; thread = thread->get_next()) {
+				T* ptr_t = thread->get_data();
+				std::move(ptr_t->begin(), ptr_t->end(), dest);
+				*ptr_t = T{};
+			}
+		};
 
-		for (thread_data* thread = head; thread != nullptr; thread = thread->get_next()) {
-			T* ptr_t = thread->get_data();
-			std::move(ptr_t->begin(), ptr_t->end(), dest);
-			*ptr_t = T{};
+		if (!std::is_constant_evaluated()) {
+			std::scoped_lock sl(get_runtime_mutex());
+			gather_flattened_impl();
+		} else {
+			gather_flattened_impl();
 		}
 	}
 
 	// Perform an action on all threads data
-	template<class Fn>
-	void for_each(Fn&& fn) {
-		std::scoped_lock sl(mtx_storage);
+	template <class Fn>
+	constexpr void for_each(Fn&& fn) noexcept {
+		auto const for_each_impl = [&]() noexcept {
+			for (thread_data* thread = head; thread != nullptr; thread = thread->get_next()) {
+				fn(*thread->get_data());
+			}
 
-		for (thread_data *thread = head; thread != nullptr; thread = thread->get_next()) {
-			fn(*thread->get_data());
+			std::for_each(data.begin(), data.end(), std::forward<Fn>(fn));
+		};
+
+		if (!std::is_constant_evaluated()) {
+			std::scoped_lock sl(get_runtime_mutex());
+			for_each_impl();
+		} else {
+			for_each_impl();
 		}
-
-		std::for_each(data.begin(), data.end(), std::forward<Fn>(fn));
 	}
 
 	// Resets all data and threads
-	void reset() noexcept {
-		std::scoped_lock sl(mtx_storage);
+	constexpr void reset() noexcept {
+		auto const reset_impl = [&]() noexcept {
+			for (thread_data* thread = head; thread != nullptr;) {
+				auto next = thread->get_next();
+				thread->remove(this);
+				thread = next;
+			}
 
-		for (thread_data *thread = head; thread != nullptr;) {
-			auto next = thread->get_next();
-			thread->remove(this);
-			thread = next;
+			head = nullptr;
+			data.clear();
+		};
+
+		if (!std::is_constant_evaluated()) {
+			std::scoped_lock sl(get_runtime_mutex());
+			reset_impl();
+		} else {
+			reset_impl();
 		}
-
-		head = nullptr;
-		data.clear();
 	}
 };
 } // namespace tls

--- a/include/tls/collect.h
+++ b/include/tls/collect.h
@@ -176,16 +176,16 @@ public:
 	}
 
 	// Gathers all the threads data and sends it to the output iterator. This clears all stored data.
-	[[nodiscard]] constexpr void gather_flattened(std::output_iterator<typename T::value_type> auto dest) noexcept {
+	constexpr void gather_flattened(auto dest_iterator) noexcept {
 		auto const gather_flattened_impl = [&]() noexcept {
 			for (T& t : data) {
-				std::move(t.begin(), t.end(), dest);
+				std::move(t.begin(), t.end(), dest_iterator);
 			}
 			data.clear();
 
 			for (thread_data* thread = head; thread != nullptr; thread = thread->get_next()) {
 				T* ptr_t = thread->get_data();
-				std::move(ptr_t->begin(), ptr_t->end(), dest);
+				std::move(ptr_t->begin(), ptr_t->end(), dest_iterator);
 				*ptr_t = T{};
 			}
 		};

--- a/include/tls/collect.h
+++ b/include/tls/collect.h
@@ -2,7 +2,6 @@
 #define TLS_COLLECT_H
 
 #include <mutex>
-#include <variant>
 #include <vector>
 
 namespace tls {

--- a/include/tls/collect.h
+++ b/include/tls/collect.h
@@ -9,9 +9,11 @@ namespace tls {
 // Works like tls::split, except data is preserved when threads die.
 // You can collect the thread_local T's with collect::gather,
 // which also resets the data on the threads by moving it.
-// Note: Two collect<T> instances in the same thread will point to the same data.
-//       Differentiate between them by passing different types to 'UnusedDifferentiaterType'.
-//       As the name implies, it's not used internally, so just put whatever.
+// Note: Two runtime collect<T> instances in the same thread will point to the same data.
+//       If they are evaluated in a constant context each instance has their own data.
+//       Differentiate between runtime versions by passing different types to 'UnusedDifferentiaterType',
+// 	     so fx collect<int, struct A> is different from collect<int, struct B>.
+//       As the name implies, 'UnusedDifferentiaterType' is not used internally, so just put whatever.
 template <typename T, typename UnusedDifferentiaterType = void>
 class collect {
 	// This struct manages the instances that access the thread-local data.

--- a/unittest/collect/collect.cpp
+++ b/unittest/collect/collect.cpp
@@ -45,7 +45,7 @@ constexpr bool test_reset() {
 constexpr bool test_gather_flatten() {
 	std::vector<int> vec(17 /*std::thread::hardware_concurrency()*/, 1);
 	tls::collect<std::vector<int>> collector;
-	int counter = 0;
+	size_t counter = 0;
 
 	std::for_each(/*std::execution::par,*/ vec.begin(), vec.end(), [&](int const) {
 		collector.local().push_back(2);

--- a/unittest/collect/collect.cpp
+++ b/unittest/collect/collect.cpp
@@ -1,94 +1,164 @@
+#include "../catch.hpp"
 #include <execution>
 #include <tls/collect.h>
-#include "../catch.hpp"
+
+constexpr bool test_constexpr() {
+	tls::collect<int> ce_test;
+	return true;
+}
+
+constexpr bool test_for_each() {
+	tls::collect<int> ce_test;
+	ce_test.local() = 4;
+
+	// test for_each
+	bool check_for_each = true;
+	ce_test.for_each([&check_for_each](int i) { check_for_each = check_for_each && (i == 4); });
+	return check_for_each;
+}
+
+constexpr bool test_gather() {
+	std::vector<int> vec(10, 1);
+	tls::collect<int> acc;
+
+	// for_each with an execution policy is not constexpr, for obv. reasons
+	std::for_each(/*std::execution::par,*/ vec.begin(), vec.end(), [&acc](int const i) { acc.local() += i; });
+
+	bool is_val_ten = true;
+	acc.for_each([&is_val_ten](int const& i) { is_val_ten = is_val_ten && (i == 10); });
+
+	auto const gathered = acc.gather();
+	return gathered.size() == 1 && gathered.front() == 10 && acc.local() == int{};
+}
+
+constexpr bool test_reset() {
+	std::vector<int> vec(1024, 1);
+	tls::collect<int> acc;
+
+	std::for_each(vec.begin(), vec.end(), [&acc](int const i) { acc.local() += i; });
+	acc.reset();
+
+	auto const collect = acc.gather();
+	return 0 == collect.size();
+}
+
+constexpr bool test_gather_flatten() {
+	std::vector<int> vec(17 /*std::thread::hardware_concurrency()*/, 1);
+	tls::collect<std::vector<int>> collector;
+	int counter = 0;
+
+	std::for_each(/*std::execution::par,*/ vec.begin(), vec.end(), [&](int const) {
+		collector.local().push_back(2);
+		counter += 1;
+	});
+
+	vec.clear();
+	collector.gather_flattened(std::back_inserter(vec));
+	if (vec.size() != counter)
+		return false;
+
+	for (int i : vec)
+		if (2 != i)
+			return false;
+	return true;
+}
+
 
 TEST_CASE("tls::collect<> specification") {
-    SECTION("new instances are default initialized") {
-        struct test {
-            int x = 4;
-        };
-        REQUIRE(tls::collect<int>().local() == int{});
-        REQUIRE(tls::collect<double>().local() == double{});
-        REQUIRE(tls::collect<test>().local().x == test{}.x);
-    }
+	SECTION("constexpr friendly") {
+		static_assert(test_constexpr());
+		static_assert(test_for_each());
+		static_assert(test_gather());
+		static_assert(test_reset());
+		static_assert(test_gather_flatten());
+	}
 
-    SECTION("does not cause data races") {
-        std::vector<int> vec(1024 * 1024, 1);
-        tls::collect<int> acc;
+	SECTION("new instances are default initialized") {
+		struct test {
+			int x = 4;
+		};
+		REQUIRE(tls::collect<int>().local() == int{});
+		REQUIRE(tls::collect<double>().local() == double{});
+		REQUIRE(tls::collect<test>().local().x == test{}.x);
+	}
 
-        std::for_each(std::execution::par, vec.begin(), vec.end(), [&acc](int const& i) { acc.local() += i; });
+	SECTION("does not cause data races") {
+		std::vector<int> vec(1024 * 1024, 1);
+		tls::collect<int> acc;
 
-        auto const collect = acc.gather();
-        int result = std::reduce(collect.begin(), collect.end());
-        REQUIRE(result == 1024 * 1024);
-    }
+		std::for_each(std::execution::par, vec.begin(), vec.end(), [&acc](int const i) { acc.local() += i; });
 
-    SECTION("gather cleans up properly") {
-        std::vector<int> vec(1024, 1);
-        tls::collect<int> acc;
+		auto const collect = acc.gather();
+		int result = std::reduce(collect.begin(), collect.end());
+		REQUIRE(result == 1024 * 1024);
+	}
 
-        std::for_each(std::execution::par, vec.begin(), vec.end(), [&acc](int const& i) { acc.local() += i; });
+	SECTION("gather cleans up properly") {
+		std::vector<int> vec(1024, 1);
+		tls::collect<int> acc;
 
-        acc.for_each([](int const& i) { REQUIRE(i > 0); });
-        (void) acc.gather();
+		std::for_each(std::execution::par, vec.begin(), vec.end(), [&acc](int const i) { acc.local() += i; });
+
+		acc.for_each([](int const& i) { REQUIRE(i > 0); });
+		(void)acc.gather();
 		acc.for_each([](int const& i) { REQUIRE(i == 0); });
 	}
 
-    SECTION("reseting after use cleans up properly") {
-        std::vector<int> vec(1024, 1);
-        tls::collect<int> acc;
+	SECTION("reseting after use cleans up properly") {
+		std::vector<int> vec(1024, 1);
+		tls::collect<int> acc;
 
-        std::for_each(std::execution::par, vec.begin(), vec.end(), [&acc](int const& i) { acc.local() += i; });
-        acc.reset();
+		std::for_each(std::execution::par, vec.begin(), vec.end(), [&acc](int const i) { acc.local() += i; });
+		acc.reset();
 
-        auto const collect = acc.gather();
-        REQUIRE(collect.size() == 0);
-    }
+		auto const collect = acc.gather();
+		REQUIRE(collect.size() == 0);
+	}
 
-    SECTION("multiple instances in same scope points to the same data") {
-        tls::collect<int> s1, s2, s3;
-        s1.local() = 1;
-        s2.local() = 2;
-        s3.local() = 3;
-        CHECK(s1.local() == 3);
-        CHECK(s2.local() == 3);
-        CHECK(s3.local() == 3);
+	SECTION("multiple instances in same scope points to the same data") {
+		tls::collect<int> s1, s2, s3;
+		s1.local() = 1;
+		s2.local() = 2;
+		s3.local() = 3;
+		CHECK(s1.local() == 3);
+		CHECK(s2.local() == 3);
+		CHECK(s3.local() == 3);
 
-        tls::collect<int, bool> s4;
-        tls::collect<int, char> s5;
-        tls::collect<int, short> s6;
-        s4.local() = 1;
-        s5.local() = 2;
-        s6.local() = 3;
-        CHECK(s4.local() == 1);
-        CHECK(s5.local() == 2);
-        CHECK(s6.local() == 3);
-    }
+		tls::collect<int, bool> s4;
+		tls::collect<int, char> s5;
+		tls::collect<int, short> s6;
+		s4.local() = 1;
+		s5.local() = 2;
+		s6.local() = 3;
+		CHECK(s4.local() == 1);
+		CHECK(s5.local() == 2);
+		CHECK(s6.local() == 3);
+	}
 
-    SECTION("data does not persist between out-of-scope instances") {
+	SECTION("data does not persist between out-of-scope instances") {
 		{
 			tls::collect<int> s1;
 			s1.local() = 1;
 			CHECK(s1.local() == 1);
 		}
 
-        {
+		{
 			tls::collect<int> s2;
 			CHECK(s2.local() != 1);
 		}
-    }
+	}
 
 	SECTION("gather flatten works") {
 		std::vector<int> vec(std::thread::hardware_concurrency(), 1);
 		tls::collect<std::vector<int>> collector;
-        std::atomic_int counter = 0;
+		std::atomic_int counter = 0;
 
-        std::for_each(std::execution::par, vec.begin(), vec.end(), [&](int const&) {
+		std::for_each(std::execution::par, vec.begin(), vec.end(), [&](int const&) {
 			collector.local().push_back(2);
 			counter += 1;
 		});
 
-        vec.clear();
+		vec.clear();
 		collector.gather_flattened(std::back_inserter(vec));
 		REQUIRE(vec.size() == counter);
 		for (int i : vec)


### PR DESCRIPTION
In constant evaluated context tls::collect will not use mutexes and thread_local data, multi-threading is runtime-only thing. It will instead basically behave as a type wrapper, with a single value per tls::collect. This is different from the runtime version, where two collects will point to the same value in a thread.

```cpp
tls::collect<int> a, b;
```
Here `a` and `b` will refer to the same `int` at runtime, but will have distinct values at compiletime